### PR TITLE
CASMINST-2848: Add timeout-settings

### DIFF
--- a/src/config/general.h
+++ b/src/config/general.h
@@ -156,6 +156,22 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define CERT_CMD		/* Certificate management commands */
 
 /*
+ * DHCP-specific options
+ *
+ */
+#undef DHCP_DISC_START_TIMEOUT_SEC
+#define DHCP_DISC_START_TIMEOUT_SEC	4
+
+#undef DHCP_DISC_END_TIMEOUT_SEC
+#define DHCP_DISC_END_TIMEOUT_SEC	32
+
+#undef DHCP_DISC_MAX_DEFERRALS
+#define DHCP_DISC_MAX_DEFERRALS		180
+
+#undef LINK_WAIT_TIMEOUT
+#define LINK_WAIT_TIMEOUT ( 45 * TICKS_PER_SEC )
+
+/*
  * ROM-specific options
  *
  */


### PR DESCRIPTION
# Summary and Scope
Add timeout-settings to adjust DHCP timeouts. The goal is to improve
boot success.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  Y/N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .version, .rpm_version, .spec, Chart.yaml

# Issues and Related PRs
Resolves CASMCMS-2848

# Testing
I built a cray-ipxe image using this base Docker image and pushed it to a machine, altered the cray-ipxe deployment to pull it in, and successfully deployed it. I then waited for it to rebuild the ipxe binary and booted a node which successfully booted with the binary.

LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

Was a fresh Install tested? Y/N   If not, Why? N
Was an Upgrade tested?      Y/N   If not, Why? N
Was a Downgrade tested?     Y/N.  If not, Why? N

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER)
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

# Risks and Mitigations
Low