### PR TITLE
Release 2.4.62

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence, the
 # owners listed in this stanza will be requested for review
 # when someone opens a pull request.
-*       @Cray-HPE/CMS-core-boot-services
+*	@Cray-HPE/Cray-Management-Systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.62] - 2023-02-28
 ### Changed
 - Undefined NET_PROTO_LACP
+- Code owners changed to Cray-Management-Systems
 
 ## [2.4.61] - 2022-12-20
 ### Added
@@ -14,3 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.60] - 2021-08-31
 - Released into csm-1.2
+
+[Unreleased]: https://github.com/Cray-HPE/ipxe-tpsw-clone/compare/v2.4.62...HEAD
+[2.4.62]: https://github.com/Cray-HPE/ipxe-tpsw-clone/compare/v2.4.61...2.4.62
+[2.4.61]: https://github.com/Cray-HPE/ipxe-tpsw-clone/compare/v2.4.60...2.4.61	


### PR DESCRIPTION
- Make all of CMS CODEOWNERS
- CASM-3876: Undefine the link aggregation protocol
- Prepare release 2.4.62

## Summary and Scope

Release version 2.4.62

## Issues and Related PRs
* Resolves [CASM-3876]

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Surtur'

### Test description:

Uploaded a new copy of the Docker image that was built using this one as a base. Then, I
rebooted a UAN node and a compute node successfully.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Low.


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

